### PR TITLE
Promote positioning statement to hero, demote tagline to subhead

### DIFF
--- a/index.html
+++ b/index.html
@@ -1853,6 +1853,7 @@
             </div>
 
             <h1 class="hero-title"></h1>
+            <p class="hero-subtitle hero-tagline"></p>
 
             <div class="hero-badges">
                 <span class="badge">Crafted by parents</span>
@@ -2663,7 +2664,8 @@
             en: {
                 // Hero Section
                 hero: {
-                    title: "Bedtime stories that build children's confidence from the inside out.",
+                    title: "Loomi helps parents turn bedtime into a daily ritual for building their child's inner voice.",
+                    tagline: "Bedtime stories that build children's confidence from the inside out.",
                     badges: [
                         "Crafted by parents",
                         "Rooted in research",
@@ -3036,6 +3038,11 @@
             const heroTitle = document.querySelector('.hero-title');
             if (heroTitle && content.hero && content.hero.title) {
                 heroTitle.textContent = content.hero.title;
+            }
+
+            const heroTagline = document.querySelector('.hero-tagline');
+            if (heroTagline && content.hero && content.hero.tagline) {
+                heroTagline.textContent = content.hero.tagline;
             }
 
             const badges = document.querySelectorAll('.hero-badges .badge');


### PR DESCRIPTION
## Summary

Restructures the hero so the parent-facing positioning statement leads and the previous outcome-focused tagline supports it as a subhead.

**Before:**
- H1: "Bedtime stories that build children's confidence from the inside out."

**After:**
- H1: "Loomi helps parents turn bedtime into a daily ritual for building their child's inner voice."
- Tagline (subhead): "Bedtime stories that build children's confidence from the inside out."

Rationale: the previous hero captured the *outcome* but didn't say what Loomi actually *does* for parents. The new H1 names the action (turning bedtime into a daily ritual) and the deeper benefit (building a child's inner voice). The old hero copy is too good to lose, so it slides into the supporting tagline slot.

## Changes

- `index.html`
  - Add `<p class="hero-subtitle hero-tagline"></p>` below the H1. Reuses the existing `.hero-subtitle` CSS class (already styled at 24px, lighter colour, mobile-responsive), so no new CSS rules needed.
  - Add `hero.tagline` field to the `en` CONTENT object alongside `hero.title`.
  - Update the JS injector to populate `.hero-tagline` from `content.hero.tagline`.

## Conflicts with PR #3

This PR and #3 both touch the hero region of `index.html`, but in different sub-regions:
- This PR adds a `<p>` element between the H1 and the badges row
- PR #3 swaps the CTA button at the bottom of the hero for the App Store badge + secondary link

Whichever merges second will need a 1-line conflict resolution — keep both changes. No logic overlap.

## Test plan

- [x] Hero H1 reads "Loomi helps parents turn bedtime into a daily ritual for building their child's inner voice."
- [x] Below the H1, the tagline reads "Bedtime stories that build children's confidence from the inside out."
- [x] Tagline renders in the existing `.hero-subtitle` styling (24px, soft purple, centered, with 800px max-width on desktop)
- [x] Mobile layout holds — both lines wrap cleanly, no overflow
- [x] Browser tab title (still "...build confidence from the inside out") matches the tagline, not the H1 — intentional, the tab needs the punchier short form
- [x] No console errors

## Out of scope (queued)

- es / fa translations for the new H1 + tagline (paired with the earlier translation queue)