### PR TITLE
Add Support link to footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -11,6 +11,7 @@ function renderFooter() {
         <div class="footer-links">
             <a href="./privacy.html">Privacy Policy</a>
             <a href="./terms.html">Terms of Service</a>
+            <a href="./support.html">Support</a>
         </div>
     `;
 }


### PR DESCRIPTION
## Summary

- Add Support link to shared footer alongside Privacy and Terms.

## Why

Loomi support page exists at /support but wasn't linked from the footer. Adding it so the support entry point is discoverable from every page on loomi.kids.

Refs loomi-iOS-app#224 (App Review v1.0.0 rejection cleanup).

## Test plan

- [x] Visual check after merge: footer shows Privacy | Terms | Support
- [ ] All three footer links resolve to a 200