### PR TITLE
Add GA launch campaign email system (thank-you + offer code + review nudge)

### DIFF
--- a/scripts/Code.js
+++ b/scripts/Code.js
@@ -10,6 +10,12 @@
 // Live App Store URL — used in the welcome email's "Install Loomi" CTA.
 var APP_STORE_LINK = "https://apps.apple.com/app/loomi-sleep-stories-for-kids/id6757821754";
 
+// App Store review deep-link — opens straight to the write-review screen.
+var APP_STORE_REVIEW_LINK = "https://apps.apple.com/app/loomi-sleep-stories-for-kids/id6757821754?action=write-review";
+
+// Name of the spreadsheet tab that drives the GA launch campaign.
+var GA_SHEET_NAME = "GA Campaign";
+
 // Handle form submissions from landing page
 function doPost(e) {
   var output = ContentService.createTextOutput();
@@ -207,6 +213,390 @@ function sendUserConfirmation(parentName, email) {
 
 
 // ============================================
+// GA LAUNCH CAMPAIGN — thank-you + offer code to early testers
+//
+// Two emails, sent from a dedicated "GA Campaign" sheet tab:
+//   1. GA announcement — thanks the tester, gifts a one-year Loomi
+//      Premium offer code, and asks (does not require) a review.
+//   2. Review nudge — a gentle reminder a few days later.
+//
+// Sheet column layout (tab named per GA_SHEET_NAME):
+//   A Name | B Email | C Offer Code | D GA Email Sent | E Review Nudge Sent
+//
+// The offer code is read per-row from column C. Paste codes harvested
+// from App Store Connect there, one per tester. Rows with a blank code
+// are skipped — a gift email with a missing code never goes out.
+// ============================================
+
+// Shared HTML shell for branded Loomi emails. Pass in the inner <tr>...</tr>
+// content; it gets wrapped with the navy starfield background, logo header
+// and footer. (The older sendUserConfirmation predates this helper and keeps
+// its own inline shell — left as-is to avoid touching the live form path.)
+function loomiEmailShell(innerHtml) {
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;500;600&display=swap" rel="stylesheet">
+    </head>
+    <body style="margin: 0; padding: 0; background-color: #0a0e1f; font-family: 'Fredoka', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;">
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color: #0a0e1f;">
+        <tr>
+          <td align="center" style="padding: 40px 20px; background: url('https://www.loomi.kids/assets/starfield-tile-transparent.png') repeat, linear-gradient(to bottom, #0a0e1f 0%, #141b2d 50%, #1a2332 100%); background-color: #0a0e1f;">
+            <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 600px; background: rgba(10, 14, 31, 0.65); border-radius: 20px; border: 1px solid rgba(255, 255, 255, 0.08);">
+
+              <!-- Logo Header -->
+              <tr>
+                <td align="center" style="padding: 40px 40px 30px;">
+                  <img src="https://www.loomi.kids/assets/loomi-logo-header.png" alt="Loomi" width="120" style="display: block;">
+                </td>
+              </tr>
+
+              ${innerHtml}
+
+              <!-- Footer -->
+              <tr>
+                <td style="padding: 30px 40px; border-top: 1px solid rgba(255, 255, 255, 0.08);">
+                  <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                    <tr>
+                      <td align="center" style="padding-bottom: 12px;">
+                        <img src="https://www.loomi.kids/apple-touch-icon.png" alt="Loomi" width="24" height="24" style="display: inline-block; vertical-align: middle; border-radius: 6px;">
+                        <span style="color: #8b9dc3; font-size: 13px; margin-left: 8px; vertical-align: middle;">Bedtime stories that build children's confidence from the inside out.</span>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center">
+                        <p style="color: #6b7a99; font-size: 12px; margin: 0; line-height: 1.5;">
+                          &#169; 2026 Loomi. Built with &#10084;&#65039; by 3 brothers and dads for parents seeking peaceful bedtimes.
+                        </p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="padding-top: 12px;">
+                        <a href="https://www.loomi.kids" style="color: #8b9dc3; font-size: 12px; text-decoration: none;">www.loomi.kids</a>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>
+    </html>
+  `;
+}
+
+// First-name helper — "Shahin Zangenehpour" -> "Shahin", blank -> "there".
+function firstNameOf(name) {
+  var n = (name || '').toString().trim();
+  return n ? n.split(/\s+/)[0] : 'there';
+}
+
+// ============================================
+// EMAIL 1: GA announcement + one-year offer code
+// ============================================
+function sendGAAnnouncement(name, email, offerCode) {
+  var firstName = firstNameOf(name);
+  var subject = "A gift for one of Loomi's first families 🌙";
+
+  var inner = `
+    <tr>
+      <td style="padding: 0 40px;">
+        <h1 style="color: #ffffff; font-size: 25px; font-weight: 600; margin: 0 0 22px; text-align: center; line-height: 1.35;">
+          Hi ${firstName}, and a sleepy hello to your little one too! &#127769;
+        </h1>
+
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 22px;">
+          You're one of the very first families to tuck in with Loomi, and we can't thank you enough. Every bit of feedback you shared went straight into the heart of this app. You didn't just test Loomi ... you helped us build it. &#128156;
+        </p>
+
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 26px;">
+          Today, Loomi is officially on the App Store.
+        </p>
+
+        <!-- A little wish -->
+        <h2 style="color: #ffffff; font-size: 19px; font-weight: 600; margin: 0 0 12px;">
+          A little wish from our team
+        </h2>
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 14px;">
+          If bedtime with Loomi has brought a few peaceful moments to your home, an honest review on the App Store would mean the world. A sentence or two is plenty. What helps most:
+        </p>
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 0 0 18px;">
+          <tr><td style="color: #a5b4fc; font-size: 15px; line-height: 1.8; padding-left: 6px;">
+            &#8226;&nbsp; Your child's age and their favourite story or culture<br>
+            &#8226;&nbsp; A sweet bedtime moment you noticed<br>
+            &#8226;&nbsp; What feels different about Loomi
+          </td></tr>
+        </table>
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 0 0 30px;">
+          <tr>
+            <td align="center">
+              <a href="${APP_STORE_REVIEW_LINK}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #8b5cf6 100%); color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 30px;">Leave a review</a>
+            </td>
+          </tr>
+        </table>
+
+        <!-- A thank-you gift (given unconditionally — not tied to the review) -->
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 0 0 26px;">
+          <tr>
+            <td style="background: rgba(244, 164, 96, 0.1); border: 1px solid rgba(244, 164, 96, 0.3); border-radius: 16px; padding: 26px; text-align: center;">
+              <p style="color: #ffffff; font-size: 19px; font-weight: 600; margin: 0 0 6px;">
+                &#127873; A thank-you gift
+              </p>
+              <p style="color: #a5b4fc; font-size: 15px; line-height: 1.6; margin: 0 0 18px;">
+                One full year of Loomi Premium, on us.
+              </p>
+              <div style="background: #0a0e1f; border: 1px dashed rgba(244, 164, 96, 0.55); border-radius: 10px; padding: 14px 22px; display: inline-block;">
+                <span style="color: #f4a460; font-size: 22px; font-weight: 600; letter-spacing: 2px; font-family: 'Courier New', Courier, monospace;">${offerCode}</span>
+              </div>
+              <p style="color: #8b9dc3; font-size: 13px; line-height: 1.6; margin: 16px 0 0;">
+                Redeem in the app: Settings &#8594; Redeem Code.<br>
+                Unlocks all 25 stories, every age band, and our 30-minute deep sleep editions.
+              </p>
+            </td>
+          </tr>
+        </table>
+
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 22px;">
+          Sweet dreams to your whole family. Here's to many more snuggly bedtimes together. &#127775;
+        </p>
+
+        <p style="color: #ffffff; font-size: 16px; margin: 0 0 4px;">
+          With love,<br>
+          <span style="color: #f4a460;">Shawn &amp; the Loomi Team</span>
+        </p>
+      </td>
+    </tr>
+  `;
+
+  var plainBody =
+    "Hi " + firstName + ", and a sleepy hello to your little one too!\n\n" +
+    "You're one of the very first families to tuck in with Loomi, and we can't thank you enough. Every bit of feedback you shared went straight into the heart of this app. You didn't just test Loomi ... you helped us build it.\n\n" +
+    "Today, Loomi is officially on the App Store.\n\n" +
+    "A LITTLE WISH FROM OUR TEAM\n" +
+    "If bedtime with Loomi has brought a few peaceful moments to your home, an honest review on the App Store would mean the world. A sentence or two is plenty. What helps most:\n" +
+    " - Your child's age and their favourite story or culture\n" +
+    " - A sweet bedtime moment you noticed\n" +
+    " - What feels different about Loomi\n" +
+    "Leave a review: " + APP_STORE_REVIEW_LINK + "\n\n" +
+    "A THANK-YOU GIFT\n" +
+    "One full year of Loomi Premium, on us.\n\n" +
+    "    " + offerCode + "\n\n" +
+    "Redeem in the app: Settings -> Redeem Code. Unlocks all 25 stories, every age band, and our 30-minute deep sleep editions.\n\n" +
+    "Sweet dreams to your whole family. Here's to many more snuggly bedtimes together.\n\n" +
+    "With love,\n" +
+    "Shawn & the Loomi Team\n" +
+    "www.loomi.kids";
+
+  GmailApp.sendEmail(email, subject, plainBody, {
+    htmlBody: loomiEmailShell(inner),
+    from: "hello@loomi.kids",
+    name: "Loomi"
+  });
+}
+
+// ============================================
+// EMAIL 2: gentle review nudge (sent a few days after email 1)
+// ============================================
+function sendReviewNudge(name, email) {
+  var firstName = firstNameOf(name);
+  var subject = "One last little favour 🌙";
+
+  var inner = `
+    <tr>
+      <td style="padding: 0 40px;">
+        <h1 style="color: #ffffff; font-size: 25px; font-weight: 600; margin: 0 0 22px; text-align: center; line-height: 1.35;">
+          Hi ${firstName} &#127769;
+        </h1>
+
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 22px;">
+          We hope your free year of Loomi Premium is already making bedtimes a little softer. If you haven't redeemed it yet, it's waiting for you in the app: Settings &#8594; Redeem Code.
+        </p>
+
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 22px;">
+          One last little favour: if Loomi has earned a place in your bedtime routine, an honest review on the App Store helps other tired parents find us. A sentence or two is all it takes ... and it genuinely makes a difference for a small team like ours.
+        </p>
+
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 8px 0 28px;">
+          <tr>
+            <td align="center">
+              <a href="${APP_STORE_REVIEW_LINK}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #8b5cf6 100%); color: #ffffff; font-size: 16px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 30px;">Leave a review</a>
+            </td>
+          </tr>
+        </table>
+
+        <p style="color: #a5b4fc; font-size: 16px; line-height: 1.7; margin: 0 0 22px;">
+          Either way, thank you for being one of the first families to believe in Loomi. It means everything.
+        </p>
+
+        <p style="color: #ffffff; font-size: 16px; margin: 0 0 4px;">
+          Sweet dreams,<br>
+          <span style="color: #f4a460;">Shawn &amp; the Loomi Team</span>
+        </p>
+      </td>
+    </tr>
+  `;
+
+  var plainBody =
+    "Hi " + firstName + "!\n\n" +
+    "We hope your free year of Loomi Premium is already making bedtimes a little softer. If you haven't redeemed it yet, it's waiting for you in the app: Settings -> Redeem Code.\n\n" +
+    "One last little favour: if Loomi has earned a place in your bedtime routine, an honest review on the App Store helps other tired parents find us. A sentence or two is all it takes ... and it genuinely makes a difference for a small team like ours.\n\n" +
+    "Leave a review: " + APP_STORE_REVIEW_LINK + "\n\n" +
+    "Either way, thank you for being one of the first families to believe in Loomi. It means everything.\n\n" +
+    "Sweet dreams,\n" +
+    "Shawn & the Loomi Team\n" +
+    "www.loomi.kids";
+
+  GmailApp.sendEmail(email, subject, plainBody, {
+    htmlBody: loomiEmailShell(inner),
+    from: "hello@loomi.kids",
+    name: "Loomi"
+  });
+}
+
+// ============================================
+// GA CAMPAIGN — sheet setup + batch senders
+// ============================================
+
+// One-time setup: create the "GA Campaign" tab with the expected headers.
+function setupGACampaignSheet() {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ui = SpreadsheetApp.getUi();
+  if (ss.getSheetByName(GA_SHEET_NAME)) {
+    ui.alert('The "' + GA_SHEET_NAME + '" tab already exists — nothing to do.');
+    return;
+  }
+  var sheet = ss.insertSheet(GA_SHEET_NAME);
+  var headers = ['Name', 'Email', 'Offer Code', 'GA Email Sent', 'Review Nudge Sent'];
+  sheet.getRange(1, 1, 1, headers.length)
+       .setValues([headers])
+       .setFontWeight('bold');
+  sheet.setFrozenRows(1);
+  sheet.setColumnWidth(1, 180);
+  sheet.setColumnWidth(2, 240);
+  sheet.setColumnWidth(3, 200);
+  sheet.setColumnWidth(4, 160);
+  sheet.setColumnWidth(5, 160);
+  ui.alert('Created the "' + GA_SHEET_NAME + '" tab.\n\n' +
+           'Fill columns A-C (Name, Email, Offer Code), select the rows, ' +
+           'then run "Send GA Announcement to Selected Rows".');
+}
+
+// Guard: returns the GA Campaign sheet only if it is the active sheet.
+function getActiveGASheetOrWarn() {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  if (sheet.getName() !== GA_SHEET_NAME) {
+    SpreadsheetApp.getUi().alert(
+      'Open the "' + GA_SHEET_NAME + '" tab first, then select the rows to send to.'
+    );
+    return null;
+  }
+  return sheet;
+}
+
+// Send the GA announcement (email 1) to the currently selected rows.
+function sendGAAnnouncementToSelectedRows() {
+  var sheet = getActiveGASheetOrWarn();
+  if (!sheet) return;
+
+  var selection = sheet.getActiveRange();
+  var startRow = selection.getRow();
+  var numRows = selection.getNumRows();
+  if (startRow === 1) { startRow = 2; numRows = numRows - 1; }  // skip header
+  if (numRows < 1) {
+    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
+    return;
+  }
+
+  var sent = 0, skippedSent = 0, skippedNoCode = 0, skippedNoEmail = 0;
+
+  for (var i = 0; i < numRows; i++) {
+    var row = startRow + i;
+    var name      = sheet.getRange(row, 1).getValue();  // A
+    var email     = sheet.getRange(row, 2).getValue();  // B
+    var offerCode = sheet.getRange(row, 3).getValue();  // C
+    var gaSent    = sheet.getRange(row, 4).getValue();  // D
+
+    if (!email)                  { skippedNoEmail++; continue; }
+    if (!offerCode)              { skippedNoCode++;  continue; }  // never send a blank-code gift
+    if (gaSent)                  { skippedSent++;    continue; }  // already sent
+
+    sendGAAnnouncement(name, email, offerCode.toString().trim());
+    sheet.getRange(row, 4).setValue(new Date());
+    sent++;
+    Utilities.sleep(600);
+  }
+
+  SpreadsheetApp.getUi().alert(
+    '✅ GA Announcement\n\n' +
+    'Sent: ' + sent + '\n' +
+    'Skipped — already sent: ' + skippedSent + '\n' +
+    'Skipped — missing offer code: ' + skippedNoCode + '\n' +
+    'Skipped — missing email: ' + skippedNoEmail
+  );
+}
+
+// Send the review nudge (email 2) to the currently selected rows.
+// Only goes to rows that already received the GA announcement.
+function sendReviewNudgeToSelectedRows() {
+  var sheet = getActiveGASheetOrWarn();
+  if (!sheet) return;
+
+  var selection = sheet.getActiveRange();
+  var startRow = selection.getRow();
+  var numRows = selection.getNumRows();
+  if (startRow === 1) { startRow = 2; numRows = numRows - 1; }
+  if (numRows < 1) {
+    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
+    return;
+  }
+
+  var sent = 0, skippedSent = 0, skippedNoGA = 0, skippedNoEmail = 0;
+
+  for (var i = 0; i < numRows; i++) {
+    var row = startRow + i;
+    var name       = sheet.getRange(row, 1).getValue();  // A
+    var email      = sheet.getRange(row, 2).getValue();  // B
+    var gaSent     = sheet.getRange(row, 4).getValue();  // D
+    var nudgeSent  = sheet.getRange(row, 5).getValue();  // E
+
+    if (!email)     { skippedNoEmail++; continue; }
+    if (!gaSent)    { skippedNoGA++;    continue; }  // don't nudge someone who never got email 1
+    if (nudgeSent)  { skippedSent++;    continue; }
+
+    sendReviewNudge(name, email);
+    sheet.getRange(row, 5).setValue(new Date());
+    sent++;
+    Utilities.sleep(600);
+  }
+
+  SpreadsheetApp.getUi().alert(
+    '✅ Review Nudge\n\n' +
+    'Sent: ' + sent + '\n' +
+    'Skipped — already nudged: ' + skippedSent + '\n' +
+    'Skipped — never got the GA email: ' + skippedNoGA + '\n' +
+    'Skipped — missing email: ' + skippedNoEmail
+  );
+}
+
+// Preview: sends both campaign emails to the address below so the team
+// can eyeball them before any real send. Uses a sample offer code.
+// Change GA_PREVIEW_EMAIL to whoever should receive the preview.
+var GA_PREVIEW_EMAIL = "shahinz@mac.com";
+function testGACampaignEmails() {
+  sendGAAnnouncement("Test Parent", GA_PREVIEW_EMAIL, "LOOMI-FAMILY-2026");
+  Utilities.sleep(800);
+  sendReviewNudge("Test Parent", GA_PREVIEW_EMAIL);
+  SpreadsheetApp.getUi().alert('Sent both campaign emails to ' + GA_PREVIEW_EMAIL + ' for preview.');
+}
+
+
+// ============================================
 // SPREADSHEET MENU
 // ============================================
 
@@ -218,6 +608,14 @@ function onOpen() {
     .addItem('Send Welcome Email to All Unsent', 'sendWelcomeToAllUnsent')
     .addSeparator()
     .addItem('Mark Selected as Welcome Sent', 'markSelectedAsWelcomeSent')
+    .addSeparator()
+    .addSubMenu(ui.createMenu('🚀 Launch Campaign')
+      .addItem('Set up GA Campaign sheet', 'setupGACampaignSheet')
+      .addSeparator()
+      .addItem('Send GA Announcement to Selected Rows', 'sendGAAnnouncementToSelectedRows')
+      .addItem('Send Review Nudge to Selected Rows', 'sendReviewNudgeToSelectedRows')
+      .addSeparator()
+      .addItem('Preview both emails (test send)', 'testGACampaignEmails'))
     .addToUi();
 }
 


### PR DESCRIPTION
## Summary

A two-email campaign for thanking early TestFlight testers as Loomi goes GA: a gift email with a one-year Loomi Premium offer code, and a follow-up review nudge. Built into the existing Loomi Apps Script (`scripts/Code.js`), driven from a dedicated spreadsheet tab.

## How it works

1. **Set up GA Campaign sheet** (menu) → creates a `GA Campaign` tab with columns: `Name | Email | Offer Code | GA Email Sent | Review Nudge Sent`
2. Paste the tester list into A-B and the App Store offer codes (harvested from App Store Connect) into column C — one code per tester
3. Select rows → **Send GA Announcement to Selected Rows** → each tester gets email 1 with their own code; column D timestamped
4. A few days later, select rows → **Send Review Nudge to Selected Rows** → email 2; column E timestamped

Safety rails:
- Rows with a **blank offer code are skipped** — a gift email with a missing code never goes out
- The review nudge only sends to rows that already received the GA email
- Per-row timestamps prevent double-sends

## Email content

- **Email 1** — Shawn's draft, rendered in the Loomi branded HTML style. Changes from the draft: "5-star review" → "an honest review" (App Store guideline 1.1.6 prohibits incentivized/star-specific review asks); "or Google Play" dropped (iOS-only launch); `[First Name]` and the code are per-user merge fields; the offer code shows in a prominent dashed code box; the gift is presented **unconditionally**, structurally separate from the review ask.
- **Email 2** — short, warm review reminder.

Both send from `hello@loomi.kids` (resolves Soushiant's from-address note automatically).

## Testing

`testGACampaignEmails()` sends both emails to `GA_PREVIEW_EMAIL` (currently `shahinz@mac.com`) using `LOOMI-FAMILY-2026` as a sample code — for team review before any real send.

## Deploy

`clasp push` publishes it. Menu functions run against HEAD, so no web-app deployment version bump is needed. `doPost` (the live form handler) is untouched.

## Known gap (not solved here)

Testers who joined via the **public TestFlight link** have no email on file and can't be reached by this campaign. An in-app announcement (Firebase Remote Config) would be the channel for them — out of scope for this PR.

## Test plan

- [x] `clasp push`, reload the spreadsheet, confirm the "🚀 Launch Campaign" submenu appears
- [x] Run "Set up GA Campaign sheet" → tab created with correct headers
- [x] Run "Preview both emails (test send)" → both emails arrive, branded correctly, code box renders, review button deep-links to the App Store write-review screen
- [x] Add a couple of test rows (one with a code, one without) → "Send GA Announcement to Selected Rows" → coded row sends, blank-code row skipped, counts reported
- [x] Re-run on the same rows → all skipped as "already sent"