### PR TITLE
MIME-encode campaign subjects so the emoji survives GmailApp

### DIFF
--- a/scripts/Code.js
+++ b/scripts/Code.js
@@ -303,12 +303,24 @@ function firstNameOf(name) {
   return n ? n.split(/\s+/)[0] : 'there';
 }
 
+// Email clients need a non-ASCII subject wrapped as an RFC 2047 "encoded-word".
+// GmailApp does not reliably encode emoji in the subject header itself — an
+// astral-plane character like 🌙 arrives mangled as "������" — so we pre-encode
+// the subject as =?UTF-8?B?<base64 of correct UTF-8 bytes>?= and let the
+// receiving client decode it. Utilities.newBlob produces correct UTF-8 (4 bytes
+// for the moon), unlike GmailApp's internal subject encoder. The HTML body is
+// unaffected; this is only for the Subject header.
+function mimeEncodeSubject(subject) {
+  var utf8Bytes = Utilities.newBlob(subject).getBytes();
+  return "=?UTF-8?B?" + Utilities.base64Encode(utf8Bytes) + "?=";
+}
+
 // ============================================
 // EMAIL 1: GA announcement + one-year offer code
 // ============================================
 function sendGAAnnouncement(name, email, offerCode) {
   var firstName = firstNameOf(name);
-  var subject = "A thank-you gift for our first families " + MOON;
+  var subject = mimeEncodeSubject("A thank-you gift for our first families " + MOON);
 
   var inner = `
     <tr>
@@ -411,7 +423,7 @@ function sendGAAnnouncement(name, email, offerCode) {
 // ============================================
 function sendReviewNudge(name, email) {
   var firstName = firstNameOf(name);
-  var subject = "A quick favour, if you have a moment " + MOON;
+  var subject = mimeEncodeSubject("A quick favour, if you have a moment " + MOON);
 
   var inner = `
     <tr>


### PR DESCRIPTION
## Summary

Second follow-up on the campaign subject-line emoji. PR #9's `String.fromCodePoint` fix made the JS string correct, but the 🌙 still arrived as `������`.

## Root cause

The corruption isn't in the source string — it's in `GmailApp.sendEmail` itself. GmailApp mis-encodes astral-plane characters (anything outside the Basic Multilingual Plane) in the **Subject header**: it encodes the UTF-16 surrogate pair as two separate 3-byte sequences (6 invalid bytes), which the receiving client renders as 6 replacement characters. The HTML **body** is unaffected because body content goes through a different, correct encoding path — which is why the body moon always rendered fine.

## Fix

Pre-encode the subject as an RFC 2047 "encoded-word" before handing it to GmailApp:

```
=?UTF-8?B?<base64 of correct UTF-8 bytes>?=
```

New `mimeEncodeSubject()` helper does this. `Utilities.newBlob(subject).getBytes()` produces correct 4-byte UTF-8 for the moon (unlike GmailApp's broken internal encoder); GmailApp then sees a pure-ASCII encoded-word and passes it through untouched; the receiving client decodes it back to 🌙.

Verified: both campaign encoded-words are 72 and 68 chars (under the RFC 2047 75-char limit, no folding needed) and round-trip cleanly back to the original strings.

The welcome-email subject is pure ASCII and left unencoded.

## Status

Already `clasp push`'d to the live script. This PR keeps the repo in sync.

## Test plan

- [x] Run "🚀 Launch Campaign → Preview both emails"
- [x] Both subject lines show the 🌙 emoji rendered correctly — no `������`
- [x] Subject text is otherwise unchanged