### PR TITLE
Open the newsletter modal when linked to with #newsletter

### DIFF
--- a/index.html
+++ b/index.html
@@ -3968,6 +3968,14 @@
         if (new URLSearchParams(window.location.search).has('app')) {
             document.body.classList.add('app-mode');
         }
+
+        // Deep link to the newsletter modal. pilot.html sends an applicant here
+        // when their child is outside the pilot's age bands, and landing on the
+        // home page with nothing open leaves them hunting for the signup.
+        // Skipped in app mode, where the modal is chrome the parent does not need.
+        if (window.location.hash === '#newsletter' && !document.body.classList.contains('app-mode')) {
+            openModal();
+        }
     </script>
 </body>
 </html>

--- a/pilot.html
+++ b/pilot.html
@@ -1082,7 +1082,7 @@
                     'Loomi itself is still for you, and we would like to keep you posted as the story library grows.'
                 ],
                 amend: { before: 'Entered the wrong age? ', text: 'Change it and send again.' },
-                link: { href: './index.html', text: 'Get product updates instead' }
+                link: { href: './index.html#newsletter', text: 'Get product updates instead' }
             },
             waitlisted: {
                 title: 'This round is full',


### PR DESCRIPTION
## Summary

- `index.html` checks for a `#newsletter` fragment on load and calls `openModal()`, in the same trailing script that already reads the URL for `?app=true`.
- `pilot.html`'s ineligible-age panel now links to `./index.html#newsletter`.
- Skipped in app mode: both apps load `index.html` as Settings → About Loomi, where the newsletter modal is chrome a parent does not need. The existing `body.app-mode` rules already hide that surface, so opening the modal there would have fought them.

A parent whose child falls outside the age bands is the one visitor we have already disappointed. Landing them on the home page with nothing open, to go and find the signup themselves, is friction in exactly the wrong place.

Nothing about the modal, its fields, its handler or its welcome email changed.

## Screenshots

No visual change on any existing surface ... the modal renders exactly as it does today, just opened by a fragment as well as by the button. The only markup change is one `href`.

## Test plan

Verified in the browser against a local server, all three paths:

- [x] `index.html#newsletter` → `modalActive: true`
- [x] `index.html` (no fragment) → `modalActive: false`
- [x] `index.html?app=true#newsletter` → `appMode: true`, `modalActive: false`
- [x] The ineligible-age panel on `pilot.html` renders `href="./index.html#newsletter"`

Closes #33.