### PR TITLE
Tag Courage as a sleep theme rather than a developmental one

### DIFF
--- a/scripts/Code.js
+++ b/scripts/Code.js
@@ -722,10 +722,13 @@ var PILOT_CHALLENGE_TAGS = {
   'other':        'neutral'
 };
 
+// Courage is tagged sleep: at bedtime a courage story is about the dark, or
+// monsters, or sleeping alone, which is a settling problem rather than a
+// developmental aim.
 var PILOT_THEME_TAGS = {
   'confidence':       'developmental',
   'calm':             'sleep',
-  'courage':          'developmental',
+  'courage':          'sleep',
   'kindness':         'developmental',
   'separation':       'sleep',
   'sibling_jealousy': 'developmental',


### PR DESCRIPTION
## Summary

Five of the seven protocol themes were tagged `developmental` and only two `sleep`, so `derivePilotAudience` ... which sums the tags ... drifted toward `developmental` for any parent who picked more than a theme or two. I authored those tags in PR #30 and flagged the imbalance at the time.

**Courage moves to `sleep`, on content grounds rather than for the arithmetic.** At bedtime a courage story is about the dark, or monsters, or sleeping alone. That is a settling problem, not a general developmental aim, and a parent reaching for it on a bedtime form is describing a child who will not settle rather than one they want braver in the abstract.

Result is 3 `sleep` / 4 `developmental`.

## Effect, measured

Ran `derivePilotAudience` both ways over realistic inputs rather than reasoning about it:

| Parent | Before | After |
|---|---|---|
| settling + courage ... "night fears" | `sleep` *(tie)* | **`sleep`** |
| resistance + all seven themes ticked | `developmental` | **`sleep` (tie)** |
| "other" challenge + courage alone | `developmental` | **`sleep`** |
| resistance + calm, separation, courage | `sleep` | `sleep` |
| confidence + confidence, kindness | `developmental` | `developmental` |
| night_waking + three developmental themes | `developmental` | `developmental` |

Row two is the bias case: a parent whose stated problem was bedtime resistance was being classified `developmental` purely because they ticked a lot of themes. It is now a tie, which writes "audience tie, review" into Notes so a human looks at it. Row one stops needing a reviewer at all.

## What this deliberately does not do

**School anxiety stays `developmental`.** An anxious child sleeps badly, but the story there is doing emotional work about school rather than about settling. Moving it as well would flip the balance to 4/3 and start fitting the tags to the arithmetic instead of the content.

**The derivation rule is untouched.** Row six above shows the residual: a parent who names a sleep challenge and then picks several developmental themes still resolves `developmental`, because the challenge and each theme carry equal weight. Whether the challenge should outweigh the theme aggregate is a protocol decision, tracked as item 4 of `TricycleLabz/loomi-workspace#1`, and belongs there rather than being changed unilaterally here.

## Scope

One object in `scripts/Code.js`, plus a comment saying why. The tag map exists in exactly one place ... `pilot.html` carries the theme ids and the parent-facing labels but no tags ... so no parent-visible copy moves and there is no visual surface to screenshot.

Note this changes classification for **future** applicants only. No rows exist yet, so there is nothing to re-derive.

## Test plan

- [x] `node --check scripts/Code.js` passes
- [x] `derivePilotAudience` exercised over six realistic inputs, before and after, results in the table above
- [x] Tag map confirmed to exist only in `scripts/Code.js`

Closes #35.