### PR TITLE
README: note that merging Code.js leaves the live script stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ cd scripts
 clasp push --force
 ```
 
+**Merging is not deploying.** A PR touching `scripts/Code.js` changes the repo and nothing else. The live script only moves when someone runs `clasp push`, and nothing detects the gap ... no CI, no warning, and no symptom until the spreadsheet menu quietly runs different logic from `main`. So after any merge that touches `Code.js`, push, and then verify rather than trusting the "Pushed 2 files" line:
+
+```bash
+# from a scratch directory, not the repo, so a stale remote cannot overwrite your work
+mkdir -p /tmp/head-check && cp scripts/.clasp.json /tmp/head-check/
+cd /tmp/head-check && clasp pull
+diff /tmp/head-check/Code.js "$OLDPWD/scripts/Code.js" && echo "in sync"
+```
+
+Pull into a scratch directory rather than running `clasp pull` in the repo, which would overwrite `scripts/Code.js` with whatever the remote happens to hold.
+
 **Gotcha — web-app deployment is version-pinned.**
 
 Menu-triggered functions (welcome email, launch-campaign senders) run against `HEAD` and pick up `clasp push` immediately.


### PR DESCRIPTION
## Summary

Adds a **"Merging is not deploying"** note to the Apps Script sync section.

A PR touching `scripts/Code.js` changes the repo and nothing else. The Apps Script only moves when someone runs `clasp push`, and nothing detects the gap ... no CI, no warning, and no symptom until the spreadsheet menu is quietly running different logic from `main`.

This already bit once. PR #36 changed a tag in `Code.js`, merged, and the live script kept the old value until it was spotted and pushed by hand. Harmless that time, because no pilot applicants can exist until the pinned deployment is redeployed. After launch, the same drift is an unpleasant thing to be debugging.

The note includes a verification recipe, because `Pushed 2 files` is not evidence that the remote matches. It pulls into a scratch directory rather than the repo, since `clasp pull` in place would overwrite `scripts/Code.js` with whatever the remote happens to hold ... which is the obvious way to check and also the way to lose work.

Docs only, no runtime change. Merges to `main` (staging), so nothing reaches the live site.

## Test plan

- [x] Both commands in the new block run verbatim from the repo root, and report `in sync` against the current remote
- [x] No em dashes in the added lines, verified against the file and attributed with `git blame` (the seven in the file all trace to #13)

Closes #37.