### PR TITLE
Stop the batch senders dropping rows from a multi-block selection

### DIFF
--- a/scripts/Code.js
+++ b/scripts/Code.js
@@ -603,6 +603,7 @@ function sendGAAnnouncementToSelectedRows() {
   if (!sheet) return;
 
   var ranges = sheet.getActiveRangeList().getRanges();
+  var seen = {};
   var considered = 0;
   var sent = 0, skippedSent = 0, skippedNoCode = 0, skippedNoEmail = 0;
 
@@ -611,10 +612,13 @@ function sendGAAnnouncementToSelectedRows() {
     var numRows = ranges[r].getNumRows();
     if (startRow === 1) { startRow = 2; numRows = numRows - 1; }  // skip header
     if (numRows < 1) continue;
-    considered += numRows;
 
     for (var i = 0; i < numRows; i++) {
       var row = startRow + i;
+      if (seen[row]) continue;  // ranges can overlap; count and act on each row once
+      seen[row] = true;
+      considered++;
+
       var name      = sheet.getRange(row, 1).getValue();  // A
       var email     = sheet.getRange(row, 2).getValue();  // B
       var offerCode = sheet.getRange(row, 3).getValue();  // C
@@ -652,6 +656,7 @@ function sendReviewNudgeToSelectedRows() {
   if (!sheet) return;
 
   var ranges = sheet.getActiveRangeList().getRanges();
+  var seen = {};
   var considered = 0;
   var sent = 0, skippedSent = 0, skippedNoGA = 0, skippedNoEmail = 0;
 
@@ -660,10 +665,13 @@ function sendReviewNudgeToSelectedRows() {
     var numRows = ranges[r].getNumRows();
     if (startRow === 1) { startRow = 2; numRows = numRows - 1; }
     if (numRows < 1) continue;
-    considered += numRows;
 
     for (var i = 0; i < numRows; i++) {
       var row = startRow + i;
+      if (seen[row]) continue;  // ranges can overlap; count and act on each row once
+      seen[row] = true;
+      considered++;
+
       var name       = sheet.getRange(row, 1).getValue();  // A
       var email      = sheet.getRange(row, 2).getValue();  // B
       var gaSent     = sheet.getRange(row, 4).getValue();  // D
@@ -1429,6 +1437,7 @@ function approvePilotSelectedRows() {
   if (!sheet) return;
 
   var ranges = sheet.getActiveRangeList().getRanges();
+  var seen = {};
   var considered = 0;
   var issued = 0, skippedNotApproved = 0, skippedHasCode = 0;
 
@@ -1437,10 +1446,13 @@ function approvePilotSelectedRows() {
     var numRows = ranges[r].getNumRows();
     if (startRow === 1) { startRow = 2; numRows = numRows - 1; }  // skip header
     if (numRows < 1) continue;
-    considered += numRows;
 
     for (var i = 0; i < numRows; i++) {
       var row = startRow + i;
+      if (seen[row]) continue;  // ranges can overlap; count and act on each row once
+      seen[row] = true;
+      considered++;
+
       var status = sheet.getRange(row, 12).getValue();  // L
       var code   = sheet.getRange(row, 13).getValue();  // M
 
@@ -1482,6 +1494,7 @@ function sendPilotApprovalToSelectedRows() {
   }
 
   var ranges = sheet.getActiveRangeList().getRanges();
+  var seen = {};
   var considered = 0;
   var sent = 0, skippedSent = 0, skippedNoCode = 0, skippedNoEmail = 0;
 
@@ -1490,10 +1503,13 @@ function sendPilotApprovalToSelectedRows() {
     var numRows = ranges[r].getNumRows();
     if (startRow === 1) { startRow = 2; numRows = numRows - 1; }  // skip header
     if (numRows < 1) continue;
-    considered += numRows;
 
     for (var i = 0; i < numRows; i++) {
       var row = startRow + i;
+      if (seen[row]) continue;  // ranges can overlap; count and act on each row once
+      seen[row] = true;
+      considered++;
+
       var name     = sheet.getRange(row, 2).getValue();   // B
       var email    = sheet.getRange(row, 3).getValue();   // C
       var device   = sheet.getRange(row, 6).getValue();   // F
@@ -1584,6 +1600,7 @@ function sendWelcomeToSelectedRows() {
   if (!sheet) return;
 
   var ranges = sheet.getActiveRangeList().getRanges();
+  var seen = {};
   var considered = 0;
   var sentCount = 0;
   var skippedCount = 0;
@@ -1597,10 +1614,13 @@ function sendWelcomeToSelectedRows() {
       numRows = numRows - 1;
     }
     if (numRows < 1) continue;
-    considered += numRows;
 
     for (var i = 0; i < numRows; i++) {
       var row = startRow + i;
+      if (seen[row]) continue;  // ranges can overlap; count and act on each row once
+      seen[row] = true;
+      considered++;
+
       var parentName = sheet.getRange(row, 2).getValue();  // Column B
       var email = sheet.getRange(row, 3).getValue();        // Column C
       var welcomeSent = sheet.getRange(row, 8).getValue();  // Column H
@@ -1677,6 +1697,7 @@ function markSelectedAsWelcomeSent() {
   if (!sheet) return;
 
   var ranges = sheet.getActiveRangeList().getRanges();
+  var seen = {};
   var marked = 0;
 
   for (var r = 0; r < ranges.length; r++) {
@@ -1691,6 +1712,14 @@ function markSelectedAsWelcomeSent() {
 
     for (var i = 0; i < numRows; i++) {
       var row = startRow + i;
+      if (seen[row]) continue;  // ranges can overlap; count and act on each row once
+      seen[row] = true;
+
+      // A blank row is not a signup. Stamping it would make the welcome email
+      // look already-sent for whoever lands on that row later, and a whole-column
+      // selection reaches every empty row on the sheet.
+      if (!sheet.getRange(row, 3).getValue()) continue;  // Column C, email
+
       sheet.getRange(row, 8).setValue(new Date());
       marked++;
     }

--- a/scripts/Code.js
+++ b/scripts/Code.js
@@ -602,32 +602,38 @@ function sendGAAnnouncementToSelectedRows() {
   var sheet = getActiveGASheetOrWarn();
   if (!sheet) return;
 
-  var selection = sheet.getActiveRange();
-  var startRow = selection.getRow();
-  var numRows = selection.getNumRows();
-  if (startRow === 1) { startRow = 2; numRows = numRows - 1; }  // skip header
-  if (numRows < 1) {
-    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
-    return;
-  }
-
+  var ranges = sheet.getActiveRangeList().getRanges();
+  var considered = 0;
   var sent = 0, skippedSent = 0, skippedNoCode = 0, skippedNoEmail = 0;
 
-  for (var i = 0; i < numRows; i++) {
-    var row = startRow + i;
-    var name      = sheet.getRange(row, 1).getValue();  // A
-    var email     = sheet.getRange(row, 2).getValue();  // B
-    var offerCode = sheet.getRange(row, 3).getValue();  // C
-    var gaSent    = sheet.getRange(row, 4).getValue();  // D
+  for (var r = 0; r < ranges.length; r++) {
+    var startRow = ranges[r].getRow();
+    var numRows = ranges[r].getNumRows();
+    if (startRow === 1) { startRow = 2; numRows = numRows - 1; }  // skip header
+    if (numRows < 1) continue;
+    considered += numRows;
 
-    if (!email)                  { skippedNoEmail++; continue; }
-    if (!offerCode)              { skippedNoCode++;  continue; }  // never send a blank-code gift
-    if (gaSent)                  { skippedSent++;    continue; }  // already sent
+    for (var i = 0; i < numRows; i++) {
+      var row = startRow + i;
+      var name      = sheet.getRange(row, 1).getValue();  // A
+      var email     = sheet.getRange(row, 2).getValue();  // B
+      var offerCode = sheet.getRange(row, 3).getValue();  // C
+      var gaSent    = sheet.getRange(row, 4).getValue();  // D
 
-    sendGAAnnouncement(name, email, offerCode.toString().trim());
-    sheet.getRange(row, 4).setValue(new Date());
-    sent++;
-    Utilities.sleep(600);
+      if (!email)                  { skippedNoEmail++; continue; }
+      if (!offerCode)              { skippedNoCode++;  continue; }  // never send a blank-code gift
+      if (gaSent)                  { skippedSent++;    continue; }  // already sent
+
+      sendGAAnnouncement(name, email, offerCode.toString().trim());
+      sheet.getRange(row, 4).setValue(new Date());
+      sent++;
+      Utilities.sleep(600);
+    }
+  }
+
+  if (!considered) {
+    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
+    return;
   }
 
   SpreadsheetApp.getUi().alert(
@@ -645,32 +651,38 @@ function sendReviewNudgeToSelectedRows() {
   var sheet = getActiveGASheetOrWarn();
   if (!sheet) return;
 
-  var selection = sheet.getActiveRange();
-  var startRow = selection.getRow();
-  var numRows = selection.getNumRows();
-  if (startRow === 1) { startRow = 2; numRows = numRows - 1; }
-  if (numRows < 1) {
-    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
-    return;
-  }
-
+  var ranges = sheet.getActiveRangeList().getRanges();
+  var considered = 0;
   var sent = 0, skippedSent = 0, skippedNoGA = 0, skippedNoEmail = 0;
 
-  for (var i = 0; i < numRows; i++) {
-    var row = startRow + i;
-    var name       = sheet.getRange(row, 1).getValue();  // A
-    var email      = sheet.getRange(row, 2).getValue();  // B
-    var gaSent     = sheet.getRange(row, 4).getValue();  // D
-    var nudgeSent  = sheet.getRange(row, 5).getValue();  // E
+  for (var r = 0; r < ranges.length; r++) {
+    var startRow = ranges[r].getRow();
+    var numRows = ranges[r].getNumRows();
+    if (startRow === 1) { startRow = 2; numRows = numRows - 1; }
+    if (numRows < 1) continue;
+    considered += numRows;
 
-    if (!email)     { skippedNoEmail++; continue; }
-    if (!gaSent)    { skippedNoGA++;    continue; }  // don't nudge someone who never got email 1
-    if (nudgeSent)  { skippedSent++;    continue; }
+    for (var i = 0; i < numRows; i++) {
+      var row = startRow + i;
+      var name       = sheet.getRange(row, 1).getValue();  // A
+      var email      = sheet.getRange(row, 2).getValue();  // B
+      var gaSent     = sheet.getRange(row, 4).getValue();  // D
+      var nudgeSent  = sheet.getRange(row, 5).getValue();  // E
 
-    sendReviewNudge(name, email);
-    sheet.getRange(row, 5).setValue(new Date());
-    sent++;
-    Utilities.sleep(600);
+      if (!email)     { skippedNoEmail++; continue; }
+      if (!gaSent)    { skippedNoGA++;    continue; }  // don't nudge someone who never got email 1
+      if (nudgeSent)  { skippedSent++;    continue; }
+
+      sendReviewNudge(name, email);
+      sheet.getRange(row, 5).setValue(new Date());
+      sent++;
+      Utilities.sleep(600);
+    }
+  }
+
+  if (!considered) {
+    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
+    return;
   }
 
   SpreadsheetApp.getUi().alert(
@@ -1571,37 +1583,47 @@ function sendWelcomeToSelectedRows() {
   var sheet = getActiveNewsletterSheetOrWarn();
   if (!sheet) return;
 
-  var selection = sheet.getActiveRange();
-  var startRow = selection.getRow();
-  var numRows = selection.getNumRows();
-
-  if (startRow === 1) {
-    startRow = 2;
-    numRows = numRows - 1;
-  }
-
+  var ranges = sheet.getActiveRangeList().getRanges();
+  var considered = 0;
   var sentCount = 0;
   var skippedCount = 0;
 
-  for (var i = 0; i < numRows; i++) {
-    var row = startRow + i;
-    var parentName = sheet.getRange(row, 2).getValue();  // Column B
-    var email = sheet.getRange(row, 3).getValue();        // Column C
-    var welcomeSent = sheet.getRange(row, 8).getValue();  // Column H
+  for (var r = 0; r < ranges.length; r++) {
+    var startRow = ranges[r].getRow();
+    var numRows = ranges[r].getNumRows();
 
-    // Skip if already sent or no email
-    if (!email || welcomeSent) {
-      skippedCount++;
-      continue;
+    if (startRow === 1) {
+      startRow = 2;
+      numRows = numRows - 1;
     }
+    if (numRows < 1) continue;
+    considered += numRows;
 
-    sendUserConfirmation(parentName, email);
+    for (var i = 0; i < numRows; i++) {
+      var row = startRow + i;
+      var parentName = sheet.getRange(row, 2).getValue();  // Column B
+      var email = sheet.getRange(row, 3).getValue();        // Column C
+      var welcomeSent = sheet.getRange(row, 8).getValue();  // Column H
 
-    // Mark as sent with timestamp in Column H
-    sheet.getRange(row, 8).setValue(new Date());
-    sentCount++;
+      // Skip if already sent or no email
+      if (!email || welcomeSent) {
+        skippedCount++;
+        continue;
+      }
 
-    Utilities.sleep(500);
+      sendUserConfirmation(parentName, email);
+
+      // Mark as sent with timestamp in Column H
+      sheet.getRange(row, 8).setValue(new Date());
+      sentCount++;
+
+      Utilities.sleep(500);
+    }
+  }
+
+  if (!considered) {
+    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
+    return;
   }
 
   SpreadsheetApp.getUi().alert(
@@ -1654,21 +1676,32 @@ function markSelectedAsWelcomeSent() {
   var sheet = getActiveNewsletterSheetOrWarn();
   if (!sheet) return;
 
-  var selection = sheet.getActiveRange();
-  var startRow = selection.getRow();
-  var numRows = selection.getNumRows();
+  var ranges = sheet.getActiveRangeList().getRanges();
+  var marked = 0;
 
-  if (startRow === 1) {
-    startRow = 2;
-    numRows = numRows - 1;
+  for (var r = 0; r < ranges.length; r++) {
+    var startRow = ranges[r].getRow();
+    var numRows = ranges[r].getNumRows();
+
+    if (startRow === 1) {
+      startRow = 2;
+      numRows = numRows - 1;
+    }
+    if (numRows < 1) continue;
+
+    for (var i = 0; i < numRows; i++) {
+      var row = startRow + i;
+      sheet.getRange(row, 8).setValue(new Date());
+      marked++;
+    }
   }
 
-  for (var i = 0; i < numRows; i++) {
-    var row = startRow + i;
-    sheet.getRange(row, 8).setValue(new Date());
+  if (!marked) {
+    SpreadsheetApp.getUi().alert('Select one or more data rows first.');
+    return;
   }
 
-  SpreadsheetApp.getUi().alert('✅ Marked ' + numRows + ' rows as Welcome email sent.');
+  SpreadsheetApp.getUi().alert('✅ Marked ' + marked + ' rows as Welcome email sent.');
 }
 
 // Test welcome email


### PR DESCRIPTION
## Summary

`sheet.getActiveRange()` returns only **one** range of a multi-range selection, so ctrl-clicking several blocks of rows silently processed the last block only, while the confirmation alert reported a plausible count that hid the omission. On the email senders that means people who should have been written to quietly were not, with nothing in the summary saying so.

Four functions moved onto `sheet.getActiveRangeList().getRanges()`, the shape `approvePilotSelectedRows` and `sendPilotApprovalToSelectedRows` already used:

- `sendWelcomeToSelectedRows`
- `markSelectedAsWelcomeSent`
- `sendGAAnnouncementToSelectedRows`
- `sendReviewNudgeToSelectedRows`

`sendWelcomeToAllUnsent` is untouched ... it scans every row rather than a selection.

## What the review caught

I ran an adversarial review on the first commit because these are live email paths, and it found the case I had flagged as the one I was least sure about.

**Ranges can overlap.** Select B2:B6, then ctrl-select D2:D6 ... two column blocks over the same people ... and `getRanges()` returns both without merging. Every row in the intersection was visited twice. No duplicate email was ever sent, because the three senders re-read the state column and skip a row stamped moments earlier by an earlier range. But every Skipped counter double-counted, and `markSelectedAsWelcomeSent`, which has no such guard, stamped those rows twice and reported **11 rows marked when 8 were**. Overstating what was sent is the same class of lie this change set out to fix.

All six selection-driven actions now keep a `seen` map and count and act on each row once, including the two pilot senders from #30 which carried the identical exposure.

## One pre-existing bug fixed alongside

`markSelectedAsWelcomeSent` stamped column H on blank rows. That is on `main` already rather than something this branch introduced, but it is fixed here because **making multi-range selection work is what makes a whole-column selection worth using**: click the column A header on a 1000-row sheet and it would stamp every empty row, so signup 41 lands on a row that already looks welcomed and never receives the email. It now skips a row with no address in column C.

Two smaller things in the same functions, both of which only became wrong once ranges are summed: `markSelectedAsWelcomeSent` reported the loop bound rather than what it stamped, and it and `sendWelcomeToSelectedRows` lacked the "select one or more data rows first" guard the GA and pilot senders have.

Skip logic, column indices, sleep intervals and alert wording are otherwise unchanged. This changes how rows are gathered, not what happens to them.

## Test plan

Exercised against a mock sheet, since Apps Script cannot run locally:

- [x] Two blocks of three rows process all six, not three ... all four functions
- [x] Overlapping 5-10 and 8-12 writes 8 stamps over 8 distinct rows and reports 8 (was 11)
- [x] Whole-column selection over a sheet holding 40 signups stamps 40 rows, not 999, reaching row 41 rather than row 1000
- [x] A block containing the header skips only that row
- [x] A header-only selection is refused by all four
- [x] A single range behaves exactly as before
- [x] `node --check` passes
- [x] `clasp push` after merge, per the README rule added in #38

No visual surface, so no screenshots.

Closes #39.