### PR TITLE
Netlify config for a staging preview of main

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,34 @@
+# Netlify serves the `main` branch as a staging preview, so the held bundle can
+# be looked at rather than only read as a diff. Production is unaffected:
+# www.loomi.kids is GitHub Pages serving `release`.
+#
+# There is no build step. The site is static files at the repo root, which is
+# what `publish` points at.
+
+[build]
+  publish = "."
+  command = ""
+
+# Only `main`. A branch deploy for every feature branch would be noise, and each
+# one would be another crawlable copy of unreleased work.
+[context.production]
+  publish = "."
+
+[context.branch-deploy]
+  publish = "."
+
+# The preview renders the Android CTAs and the pilot recruitment page, neither of
+# which is public yet. Holding them back is pointless if a search engine indexes
+# a staging copy, so nothing here is indexable.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex, nofollow, noarchive, nosnippet"
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+# scripts/, docs/ and tools/ are served as-is. Blocking them was considered and
+# dropped: the repo is public, so they are already readable on GitHub, and a
+# redirect rule would need a 404 page this site does not have. A custom 404 is
+# worth adding on its own merits, not as a dependency of this config.

--- a/pilot.html
+++ b/pilot.html
@@ -877,6 +877,15 @@
         const ENDPOINT = 'https://script.google.com/macros/s/AKfycbyG5r-zIpHmwh17xCEQR-a9tab8YPdKBfki0DXzTnbjBjTiMog3k2v5rLgnX-ukg9MXSQ/exec';
         const HAS_MONOTONIC_CLOCK = typeof performance !== 'undefined' && typeof performance.now === 'function';
 
+        // The Apps Script endpoint is the production one wherever this page is
+        // served from, so a staging copy would write real rows. Until the pilot
+        // handler is the deployed version, a submission from a staging host is
+        // worse than useless: the pinned deployment predates it, ignores the form
+        // field, and files the applicant into the newsletter tab. Submitting is
+        // therefore refused anywhere but the live site and a local server.
+        const LIVE_HOSTS = ['www.loomi.kids', 'loomi.kids', 'localhost', '127.0.0.1'];
+        const IS_LIVE_HOST = LIVE_HOSTS.indexOf(window.location.hostname) !== -1;
+
         function elapsedNow() {
             return HAS_MONOTONIC_CLOCK ? performance.now() : Date.now();
         }
@@ -1175,6 +1184,14 @@
 
             formError.hidden = true;
             if (!validate()) return;
+
+            if (!IS_LIVE_HOST) {
+                showFormError(
+                    'This is a preview of the site, so applications are not being accepted here. ' +
+                    'The live form is at www.loomi.kids/pilot.html once the pilot opens.'
+                );
+                return;
+            }
 
             const challenge = checkedValue('challenge');
             const payload = {


### PR DESCRIPTION
## Summary

GitHub Pages allows one source per repo and that slot is `release`, so there has been no way to *look* at what is sitting on `main` short of running a local server. The held bundle is fourteen commits deep, which is more than anyone should have to read as a diff.

- `netlify.toml` as config-as-code, so the setup is reproducible rather than living only in a dashboard. Static site, no build step, publish directory is the repo root.
- Everything carries `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet`. The preview renders the unreleased Android CTAs and the pilot page, and holding those back is pointless if a search engine indexes a staging copy.

## The part that needed care

The pilot form is the reason this is not just a config file.

`ENDPOINT` is the **production** Apps Script wherever the page is served from. The pinned deployment is `@11`, which predates the pilot handler ... it ignores `data.form` and falls through to the newsletter path, appending a **six-column junk row into the live newsletter signups tab**. Anyone who found the preview and filled in the form would corrupt real data, silently.

`pilot.html` now refuses to submit from any host but the live domain or a local server, and tells the visitor why. The page still renders in full, which is the point of a preview.

The host list is an **exact** match rather than a suffix check, so a lookalike does not pass:

| Host | Submits |
|---|---|
| `www.loomi.kids`, `loomi.kids` | yes |
| `localhost`, `127.0.0.1` | yes |
| `loomi-staging.netlify.app` | no |
| `deploy-preview-42--loomi.netlify.app` | no |
| `loomi.kids.evil.com` | no |

## Deliberately not done

Blocking `scripts/`, `docs/` and `tools/` from the preview. The repo is public, so they are already readable on GitHub, and a redirect rule would need a 404 page this site does not have. A custom 404 is worth adding on its own merits, not as a dependency of this config.

Netlify's password protection is a paid-plan feature. `noindex` plus an unguessable URL is what this gives you; genuinely private is a billing decision.

## What still needs a human

This PR is the config. **Creating the Netlify site and connecting the repo needs browser OAuth I cannot complete** ... a Netlify account, then the GitHub App install. Roughly two minutes:

1. Netlify → Add new site → Import an existing project → GitHub → `98ChimpInc/loomi-landing-page`
2. Set the production branch to **`main`**, not `master` or `release`
3. Leave build command empty and publish directory `.` ... `netlify.toml` already says both, so it should prefill
4. Deploy, then rename the site to something memorable under Site configuration

Nothing about production changes either way. `www.loomi.kids` stays GitHub Pages serving `release`.

## Test plan

- [x] `netlify.toml` parses as valid TOML; publish, contexts and headers verified
- [x] Submitting from `localhost` still POSTs (guard does not break local verification)
- [x] Host predicate checked against the two live domains, localhost, three Netlify hostname shapes and two lookalikes
- [x] After the site is connected: confirm the preview renders, confirm `X-Robots-Tag` is present on a response, and confirm the pilot form shows the disabled message rather than submitting

Closes #41.