### PR TITLE
Make the fan-out fail loudly, and stop Sheets coercing band and code

### DIFF
--- a/scripts/Code.js
+++ b/scripts/Code.js
@@ -789,6 +789,12 @@ function derivePilotAudience(challenge, themes) {
 
 // Create the pilot tabs if they are missing. Returns the names created.
 // They go at the end so they never shift the tabs already in the spreadsheet.
+// Columns Sheets would otherwise coerce, keyed by column number:
+//   E  every band label parses as an en-US date, so "2-3" becomes 3 February
+//   M  a code from the unambiguous alphabet can look like a number, and
+//      "2E3456" parses as scientific notation
+var PILOT_TEXT_COLUMNS = [5, 13];
+
 function ensurePilotSheets() {
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var created = [];
@@ -806,6 +812,7 @@ function ensurePilotSheets() {
     for (var i = 0; i < widths.length; i++) {
       sheet.setColumnWidth(i + 1, widths[i]);
     }
+    enforcePilotTextColumns(sheet);
     created.push(PILOT_SHEET_NAME);
   }
 
@@ -828,12 +835,33 @@ function ensurePilotSheets() {
   return created;
 }
 
+// Sheets decides a cell's type on write, so the format has to exist first.
+// Applied to the whole column below the header so future rows inherit it.
+function enforcePilotTextColumns(sheet) {
+  if (!sheet) return;
+
+  var lastRow = Math.max(sheet.getMaxRows(), 2);
+  for (var i = 0; i < PILOT_TEXT_COLUMNS.length; i++) {
+    sheet.getRange(2, PILOT_TEXT_COLUMNS[i], lastRow - 1, 1).setNumberFormat('@');
+  }
+}
+
 // One-time setup from the menu: both pilot tabs, seeded and formatted.
 function setupPilotApplicantsSheet() {
   var ui = SpreadsheetApp.getUi();
   var created = ensurePilotSheets();
+
+  // Safe to re-run, and the only way a tab created before the text format
+  // existed gets repaired. Kept here rather than in ensurePilotSheets because
+  // that runs on every submission and this walks whole columns.
+  enforcePilotTextColumns(SpreadsheetApp.getActiveSpreadsheet().getSheetByName(PILOT_SHEET_NAME));
+
   if (!created.length) {
-    ui.alert('The "' + PILOT_SHEET_NAME + '" and "' + PILOT_CONFIG_SHEET_NAME + '" tabs already exist ... nothing to do.');
+    ui.alert('The "' + PILOT_SHEET_NAME + '" and "' + PILOT_CONFIG_SHEET_NAME + '" tabs already exist.\n\n' +
+             'Re-applied the text format to the Age band and Invitation code columns, so Sheets cannot read ' +
+             'a band like "2-3" as a date or a code like "2E3456" as a number.\n\n' +
+             'Values already stored wrongly are not repaired by this: a coerced band shows as a serial number ' +
+             'and can be rebuilt from the age in column D, but a coerced code is gone and the row needs a new one.');
     return;
   }
   ui.alert('Created: ' + created.join(', ') + '.\n\n' +
@@ -1208,7 +1236,13 @@ function pilotFanOut(sheet, row, codeIssuedAt) {
       'updatedAt':           new Date()
     };
 
-    UrlFetchApp.fetch(PILOT_FANOUT_URL, {
+    // muteHttpExceptions keeps a 4xx or 5xx from throwing, so the status has to
+    // be read. Without this a rotated secret returns 401 on every row forever
+    // and the sheet still shows a clean row with a code in column M, while
+    // nothing reaches Firestore. The endpoint is the only write path into
+    // applicants, so a silent failure here is invisible until a family reports
+    // that their invitation does not work.
+    var response = UrlFetchApp.fetch(PILOT_FANOUT_URL, {
       'method': 'post',
       'contentType': 'application/json',
       'headers': { 'X-Loomi-Pilot-Secret': PropertiesService.getScriptProperties().getProperty(PILOT_FANOUT_SECRET_PROPERTY) || '' },
@@ -1216,8 +1250,30 @@ function pilotFanOut(sheet, row, codeIssuedAt) {
       'muteHttpExceptions': true
     });
 
+    var status = response.getResponseCode();
+    if (status < 200 || status > 299) {
+      // The endpoint returns a specific error body on a 400, so keep it: it
+      // names the field a reviewer has to correct.
+      var detail = (response.getContentText() || '').toString().slice(0, 300);
+      Logger.log('Pilot fan-out HTTP ' + status + ' for row ' + row + ': ' + detail);
+      pilotNoteFanOutFailure(sheet, row, 'HTTP ' + status + (detail ? ' ... ' + detail : ''));
+    }
+
   } catch (error) {
-    sheet.getRange(row, 15).setValue(pilotMergedNotes(sheet.getRange(row, 15).getValue(), 'fan-out failed: ' + error));
+    Logger.log('Pilot fan-out failed for row ' + row + ': ' + error);
+    pilotNoteFanOutFailure(sheet, row, error.toString());
+  }
+}
+
+// A fan-out failure is recorded on the row rather than thrown, because the row
+// is already committed and the applicant has already been answered.
+function pilotNoteFanOutFailure(sheet, row, reason) {
+  try {
+    sheet.getRange(row, 15).setValue(
+      pilotMergedNotes(sheet.getRange(row, 15).getValue(), 'fan-out failed: ' + reason)
+    );
+  } catch (noteError) {
+    Logger.log('Could not record fan-out failure on row ' + row + ': ' + noteError);
   }
 }
 


### PR DESCRIPTION
Both defects were found by the session building the receiving endpoint (`TricycleLabz/loomi-story-workbench#287`). I verified each against the source before fixing rather than taking them on report ... both were exactly as described.

## `pilotFanOut` discarded every HTTP failure (#43)

`muteHttpExceptions: true` keeps a 4xx or 5xx from throwing, and the `UrlFetchApp.fetch(...)` return value was unassigned, so the `catch` only ever fired on a **transport** failure. A 401 from a rotated secret, a 400 from a validation error, a 500 ... all silently ignored.

That matters more than a normal swallowed error, because the endpoint is the **only** write path into `applicants` (the rules deny create to every client). A failing fan-out leaves the sheet showing a clean row with a code in column M while nothing reaches Firestore. Nobody finds out until a family reports their invitation does not work, and a 401 is systemic rather than per-row, so it would fail every row indefinitely.

Now the response code is checked, and a non-2xx is recorded on the row with the endpoint's own error body, which names the field a reviewer has to correct. Failures also go to `Logger`, since a row can be deleted.

| Response | Notes column |
|---|---|
| 200 | *(nothing)* |
| 401 | `fan-out failed: HTTP 401 ... {"error":"bad secret"}` |
| 400 | `fan-out failed: HTTP 400 ... {"error":"band must be a string, got Date"}` |
| 500 | `fan-out failed: HTTP 500 ... upstream exploded` |
| transport throw | `fan-out failed: Error: DNS failure` |

## Band and code could be coerced by the sheet (#44)

Every band label parses as an en-US date, so `2-3` becomes 3 February. A code from the unambiguous alphabet can look numeric, and `2E3456` parses as scientific notation. The only `setNumberFormat` in the file was the config tab's B2. Columns **E** and **M** are now text.

**One thing the report could not see from outside:** `ensurePilotSheets` only formatted at creation, so a fix there would not have repaired a tab that already exists ... which is precisely the tab that might hold rows. The format is now applied at creation *and* from the menu setup action, which makes that menu item the repair path. Its alert says what it did.

It is deliberately **not** called from `ensurePilotSheets`, which runs inside the script lock on every submission and would have walked two whole columns per applicant.

## Not done, deliberately

Values already stored wrongly are not repaired automatically. A coerced band is rebuildable from the age in column D; a coerced code is unrecoverable and the row needs a new one. Writing a speculative repair routine for rows that probably do not exist yet is not worth the machinery, and both cases are visible anyway ... a text-formatted cell holding a date shows its serial number.

To check the live sheet: a left-aligned `2-3` in column E is a string, right-aligned is a date.

## Test plan

- [x] Fan-out exercised against a mocked `UrlFetchApp` for 200, 401, 400, 500 and a thrown transport error; results in the table above
- [x] A 200 writes no note, so a healthy row stays clean
- [x] `node --check` passes
- [x] Confirmed `enforcePilotTextColumns` is not reachable from `handlePilotSubmission`
- [x] After merge: `clasp push`, then run the Pilot setup menu item once to apply the format to the existing tab

Closes #43. Closes #44.