### PR TITLE
Say fourteen nights, and make timezone a real dropdown

### DIFF
--- a/pilot.html
+++ b/pilot.html
@@ -7,20 +7,20 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
 
-    <title>Loomi bedtime pilot - 21 nights of stories</title>
-    <meta name="description" content="Apply to join the Loomi bedtime pilot. 21 nights of stories, and a few short questions. All of Loomi unlocked for three weeks, and your free trial stays untouched.">
+    <title>Loomi bedtime pilot - fourteen nights of stories</title>
+    <meta name="description" content="Apply to join the Loomi bedtime pilot. Fourteen nights of stories across three weeks, and a few short questions. All of Loomi unlocked for the three weeks, and your free trial stays untouched.">
     <link rel="canonical" href="https://www.loomi.kids/pilot.html">
 
     <!-- Social preview -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://www.loomi.kids/pilot.html">
     <meta property="og:site_name" content="Loomi">
-    <meta property="og:title" content="Loomi bedtime pilot - 21 nights of stories">
-    <meta property="og:description" content="21 nights of stories, and a few short questions. All of Loomi unlocked for three weeks, and your free trial stays untouched.">
+    <meta property="og:title" content="Loomi bedtime pilot - fourteen nights of stories">
+    <meta property="og:description" content="Fourteen nights of stories across three weeks, and a few short questions. All of Loomi unlocked for the three weeks, and your free trial stays untouched.">
     <meta property="og:image" content="https://www.loomi.kids/assets/loomi-logo-header.png">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Loomi bedtime pilot - 21 nights of stories">
-    <meta name="twitter:description" content="21 nights of stories, and a few short questions. All of Loomi unlocked for three weeks, and your free trial stays untouched.">
+    <meta name="twitter:title" content="Loomi bedtime pilot - fourteen nights of stories">
+    <meta name="twitter:description" content="Fourteen nights of stories across three weeks, and a few short questions. All of Loomi unlocked for the three weeks, and your free trial stays untouched.">
     <meta name="twitter:image" content="https://www.loomi.kids/assets/loomi-logo-header.png">
 
     <!-- Favicon -->
@@ -640,7 +640,7 @@
             <main>
                 <section class="pilot-hero">
                     <p class="eyebrow">Research pilot</p>
-                    <h1>21 nights of stories, and a few short questions.</h1>
+                    <h1>Fourteen nights of stories, and a few short questions.</h1>
                     <p class="lede">We are looking for families with a child aged 2 to 5 to run Loomi at bedtime for three weeks, and tell us what actually happened.</p>
                     <!-- Fallback for a failed fetch only ... the page overwrites this with the date the server returns from the Pilot Config sheet tab, and empties it when the server reports no date. -->
                     <p class="cohort-line">Everyone starts together on <strong class="cohort-slot" id="cohort-date">5 October 2026</strong>.</p>
@@ -650,7 +650,8 @@
                     <div class="fact-card">
                         <h2>What we ask</h2>
                         <ul>
-                            <li>One story a night, 21 nights in a row.</li>
+                            <li>One story a night, for fourteen nights.</li>
+                            <li>Three weeks from first evening to last. The first three evenings and the last three carry a few questions but no story, so we can see what bedtime looks like either side of the fourteen.</li>
                             <li>A few short questions after each story. Fifteen seconds, and they can wait until the morning.</li>
                             <li>Everyone begins on the same evening, so the nights line up across the group.</li>
                         </ul>
@@ -750,12 +751,14 @@
                         <div class="form-group">
                             <label for="tz">Your time zone</label>
                             <p class="hint">We use this so the nightly questions arrive at a sensible hour. Change it if it looks wrong.</p>
-                            <input type="text" id="tz" name="tz" autocomplete="off" placeholder="America/Toronto" aria-describedby="tz-error">
+                            <!-- Populated from Intl.supportedValuesOf('timeZone') so every option is a
+                                 real IANA zone. Replaced with a text input on browsers without it. -->
+                            <select id="tz" name="tz" aria-describedby="tz-error"></select>
                             <p class="field-error" id="tz-error" hidden></p>
                         </div>
 
                         <fieldset class="form-group" id="commit-group">
-                            <legend>Can you commit to 21 nights starting on <span class="cohort-slot" data-cohort-date></span>?</legend>
+                            <legend>Can you commit to the three weeks starting on <span class="cohort-slot" data-cohort-date></span>?</legend>
                             <div class="choice-list">
                                 <label class="choice" for="commit-yes">
                                     <input type="radio" id="commit-yes" name="canCommit" value="yes" aria-describedby="commit-error">
@@ -953,14 +956,68 @@
                 });
         })();
 
-        (function prefillTimezone() {
+        // The 4am protocol-day boundary is computed in the family's own zone, and the
+        // contract requires an IANA identifier rather than an offset, so every option
+        // here comes from the platform's own list instead of anything typed.
+        (function buildTimezoneField() {
             const field = document.getElementById('tz');
+            let detected = '';
             try {
-                const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-                if (zone) field.value = zone;
+                detected = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
             } catch (error) {
-                field.value = '';
+                detected = '';
             }
+
+            let zones = [];
+            try {
+                zones = typeof Intl.supportedValuesOf === 'function'
+                    ? Intl.supportedValuesOf('timeZone')
+                    : [];
+            } catch (error) {
+                zones = [];
+            }
+
+            // Older Safari has no supportedValuesOf. Fall back to the editable text
+            // input this replaced, which is no worse than the previous behaviour.
+            if (!zones.length) {
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.id = 'tz';
+                input.name = 'tz';
+                input.autocomplete = 'off';
+                input.placeholder = 'America/Toronto';
+                input.setAttribute('aria-describedby', 'tz-error');
+                input.value = detected;
+                field.parentNode.replaceChild(input, field);
+                return;
+            }
+
+            // A detected zone the platform does not list would otherwise be unselectable.
+            if (detected && zones.indexOf(detected) === -1) zones = zones.concat(detected);
+
+            const groups = {};
+            zones.forEach(function (zone) {
+                const region = zone.indexOf('/') === -1 ? 'Other' : zone.split('/')[0];
+                (groups[region] = groups[region] || []).push(zone);
+            });
+
+            const fragment = document.createDocumentFragment();
+            Object.keys(groups).sort().forEach(function (region) {
+                const optgroup = document.createElement('optgroup');
+                optgroup.label = region.split('_').join(' ');
+                groups[region].sort().forEach(function (zone) {
+                    const option = document.createElement('option');
+                    option.value = zone;
+                    // Drop the region prefix in the label; the optgroup already carries it.
+                    option.textContent = zone.split('/').slice(1).join(' / ').split('_').join(' ') || zone;
+                    if (zone === detected) option.selected = true;
+                    optgroup.appendChild(option);
+                });
+                fragment.appendChild(optgroup);
+            });
+
+            field.appendChild(fragment);
+            if (detected) field.value = detected;
         })();
 
         form.addEventListener('change', function (event) {


### PR DESCRIPTION
## 1. The page promised 21 nights of stories. The protocol has 14.

Per `PROTOCOL_DATA_CONTRACT.md` §2:

```
day     1  2  3 | 4  5  6  7  8  9 10 11 12 13 14 15 16 17 | 18 | 19 20 21
phase   baseline| intervention                              |    | exit
night          | 1  2  3  4  5  6  7  8  9 10 11 12 13 14  | 15 |
```

Days 1 to 3 are a baseline diary with **no Loomi at all**. Days 19 to 21 are exit questions with **no story**. So it is three weeks of participation and **fourteen** story nights.

This is the exact failure the design board names: *a parent told they are on night 2 of 21 during baseline will assume they have already missed two stories.* The phrasing came from the board's own lede, which Session 0 superseded ... I carried the register across and the stale fact with it.

Fixed in the title, meta description, both social cards, the H1, the "What we ask" list and the commitment question, plus a new line saying plainly that the first three evenings and the last three carry questions but no story.

The true ask is **lighter** than the claim was, so the accurate version should recruit better, not worse.

The 10-of-15 completer threshold is deliberately still absent ... it is open for sign-off in `TricycleLabz/loomi-workspace#1` and does not belong in recruitment copy yet.

## 2. Timezone is now a select

It was free text prefilled from `Intl`, so a parent could submit a city name, a `GMT-5` offset, or a typo. That value is not cosmetic: the 4am protocol-day boundary is computed in the family's own zone, and the contract requires an IANA identifier precisely because subtracting an offset gets DST wrong twice a year.

Now built from `Intl.supportedValuesOf('timeZone')`, grouped by region, detected zone preselected. Every option is a valid identifier by construction. Native selects are type-ahead searchable, so 418 entries need no search widget and no dependency.

Browsers without `supportedValuesOf` (older Safari) get the previous text input back, prefilled with the detected zone. No regression there.

## Test plan

- [x] 418 zones across 10 region groups; detected zone preselected; labels read "Vancouver" under "America"
- [x] Changing the selection reaches the POST payload intact (`tz: "Europe/Lisbon"`, 12 keys, `childAgeMonths: 51`)
- [x] Fallback branch exercised against a stubbed `Intl` ... a modern browser cannot reach it, so it was tested directly: yields `INPUT type=text value=America/Vancouver`
- [x] No remaining claim of 21 nights anywhere in the page
- [x] Script blocks parse

## Screenshots

| Before | After |
|---|---|
| "21 nights of stories" / "One story a night, 21 nights in a row." | "Fourteen nights of stories" / "One story a night, for fourteen nights." plus the three-weeks explanation |

Captured at 1280 with `tools/screenshot.mjs` and read back before committing.

Closes #52. Closes #53.