### PR TITLE
Remove the staging skip marker, which matched its own documentation

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,12 +25,6 @@ jobs:
   deploy:
     name: Deploy to staging.loomi.kids
     runs-on: ubuntu-latest
-    # Skip runs where nothing served could have changed. The site is static files
-    # at the repo root, so a docs-only or Apps Script-only commit needs no deploy.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      !contains(github.event.head_commit.message, '[skip staging]')
-
     permissions:
       contents: read
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ git push --force-with-lease
 firebase deploy --only hosting:staging
 ```
 
-Add `[skip staging]` to a commit message to skip the deploy for a change that serves nothing, such as a docs-only or Apps Script-only commit.
-
 The workflow authenticates with a service account key in the `FIREBASE_SERVICE_ACCOUNT` repo secret. Firebase Hosting IAM has no per-site granularity, so that account can deploy to any hosting site on the project; the workflow pins the staging target, and changing it takes a PR. Moving to Workload Identity Federation would remove the long-lived key and is the better end state.
 
 Everything there carries `X-Robots-Tag: noindex`, because staging renders unreleased work and an indexed copy defeats the point of holding it. `scripts/`, `docs/`, `tools/` and `misc/` are excluded from the upload.


### PR DESCRIPTION
## What happened

The workflow gated on whether the commit message contained a skip marker. `head_commit.message` is the **whole** message, subject and body, and a squash merge puts the PR body there. So any commit that merely *mentioned* the marker skipped the deploy.

The first run proved it immediately: the PR that added the feature documented the marker, the documentation matched the condition, and **the workflow skipped its own first deploy**. Staging fell behind `main` ... which is exactly what this workflow exists to prevent ... and it failed silently, because a skipped run reports green.

## Removing rather than narrowing

The marker does not earn its cost. The deploy is a static upload of a few hundred files, so skipping a docs-only commit saves seconds. Against that: a silent-skip footgun on every future commit message, re-armed by any PR that discusses it.

If a deploy genuinely needs skipping, GitHub natively honours its own ci-skip markers with no workflow support required.

Two partial fixes considered and rejected:

- **Match only the subject line** ... cannot be expressed in a GitHub expression without an extra step to parse it.
- **Use a more obscure marker** ... narrows the collision without removing it, and the failure stays silent when it happens.

Everything else stays: the concurrency cancel, `workflow_dispatch`, and the post-deploy check that staging really returns 200.

## Test plan

- [x] No `if:` gate and no `contains()` remain in the workflow
- [x] Trigger, concurrency, pinned target and post-deploy check all still present; no tabs
- [x] No reference to the marker left in the workflow or the README
- [x] On merge: the run actually executes rather than skipping, goes green, and staging serves the current `main`

That last box is the real test, and it is the one the previous PR could not tick.

Closes #57.